### PR TITLE
구글 아이콘 스타일 추가

### DIFF
--- a/AvocadoEdition_Light/head.sub.php
+++ b/AvocadoEdition_Light/head.sub.php
@@ -65,7 +65,7 @@ if($config['cf_add_meta'])
 
 <title><?php echo $g5_head_title; ?></title>
 
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
 <?
 if (defined('G5_IS_ADMIN')) {
 	echo '<link rel="stylesheet" href="'.G5_ADMIN_URL.'/css/admin.css" type="text/css">'.PHP_EOL;


### PR DESCRIPTION
material-icons 외에 material-icons-outlined, material-icons-two-tone 등의 class를 사용할 수 있습니다.